### PR TITLE
Add remove audio slash command

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,18 +82,17 @@ async def audio(interaction: Interaction, file: Attachment):
         await interaction.followup.send(f"Erro inesperado: {str(a)}", ephemeral=True)
 
 
-@app_commands.describe(file="Remove o arquivo de áudio associado ao usuário.")
 @teli_client.tree.command(description="Remove o arquivo de áudio que toca ao entrar na sala.")
 async def remover_audio(interaction: Interaction):
     """ Command to remove the audio file associated with the user. """
-    await interaction.response.send_message(f"Removendo arquivo...", ephemeral=True)
+    await interaction.response.send_message("Removendo arquivo...", ephemeral=True)
     try:
         filepath = pathlib.Path(os.path.join("telibot", "guilds", str(interaction.guild_id), "sounds", f"{interaction.user.id}.mp3"))
         if os.path.exists(filepath):
             os.remove(filepath)
             await interaction.followup.send(f"{interaction.user.mention} seu arquivo foi removido com sucesso!", ephemeral=True)
         else:
-            await interaction.followup.send(f"Arquivo não encontrado!", ephemeral=True)
+            await interaction.followup.send("Arquivo não encontrado!", ephemeral=True)
 
     except Exception as a:
         await interaction.followup.send(f"Erro inesperado: {str(a)}", ephemeral=True)

--- a/main.py
+++ b/main.py
@@ -81,6 +81,24 @@ async def audio(interaction: Interaction, file: Attachment):
     except Exception as a:
         await interaction.followup.send(f"Erro inesperado: {str(a)}", ephemeral=True)
 
+
+@app_commands.describe(file="Remove o arquivo de áudio associado ao usuário.")
+@teli_client.tree.command(description="Remove o arquivo de áudio que toca ao entrar na sala.")
+async def remover_audio(interaction: Interaction):
+    """ Command to remove the audio file associated with the user. """
+    await interaction.response.send_message(f"Removendo arquivo...", ephemeral=True)
+    try:
+        filepath = pathlib.Path(os.path.join("telibot", "guilds", str(interaction.guild_id), "sounds", f"{interaction.user.id}.mp3"))
+        if os.path.exists(filepath):
+            os.remove(filepath)
+            await interaction.followup.send(f"{interaction.user.mention} seu arquivo foi removido com sucesso!", ephemeral=True)
+        else:
+            await interaction.followup.send(f"Arquivo não encontrado!", ephemeral=True)
+
+    except Exception as a:
+        await interaction.followup.send(f"Erro inesperado: {str(a)}", ephemeral=True)
+
+
 @teli_client.event
 async def on_message(message: discord.Message):
     """ Event that triggers when a message is sent. """


### PR DESCRIPTION
This pull request introduces a new command to the bot, allowing users to remove their associated audio file. The implementation includes error handling and user feedback.

### New Command Addition:
* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R84-R100): Added a new command `remover_audio` to allow users to delete their associated audio file. The command checks if the file exists and removes it, providing appropriate feedback to the user or handling errors gracefully.